### PR TITLE
Make CObjectViewHelper methods static

### DIFF
--- a/Classes/ViewHelpers/CObjectViewHelper.php
+++ b/Classes/ViewHelpers/CObjectViewHelper.php
@@ -51,7 +51,7 @@ class CObjectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\CObjectViewHelper
      *
      * @return void
      */
-    protected function simulateFrontendEnvironment()
+    protected static function simulateFrontendEnvironment(): void
     {
         if (empty($_SERVER['TYPO3_FRACTAL'])) {
             parent::simulateFrontendEnvironment();
@@ -64,7 +64,7 @@ class CObjectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\CObjectViewHelper
      * @return void
      * @see simulateFrontendEnvironment()
      */
-    protected function resetFrontendEnvironment()
+    protected static function resetFrontendEnvironment(): void
     {
         if (empty($_SERVER['TYPO3_FRACTAL'])) {
             parent::resetFrontendEnvironment();


### PR DESCRIPTION
Fixes `PHP Fatal error:  Cannot make static method TYPO3\CMS\Fluid\ViewHelpers\CObjectViewHelper::simulateFrontendEnvironment() non static in class Tollwerk\TwComponentlibrary\ViewHelpers\CObjectViewHelper in /var/www/html/public/typo3conf/ext/tw_componentlibrary/Classes/ViewHelpers/CObjectViewHelper.php on line 0`