### PR TITLE
Fix image links in documentation

### DIFF
--- a/Classes/Component/AbstractComponent.php
+++ b/Classes/Component/AbstractComponent.php
@@ -429,7 +429,20 @@ abstract class AbstractComponent implements ComponentInterface
         $componentFile    = $reflectionObject->getFileName();
         $docDirectory     = dirname($componentFile).DIRECTORY_SEPARATOR.$this->basename;
 
-        return $rootRelative ? substr($docDirectory, strlen(Environment::getPublicPath())) : $docDirectory;
+        if ($rootRelative) {
+            // Extract extension key with subdirectories from docDirectory
+            $extensionDirPosition = strpos($docDirectory, $this->extensionKey);
+            $extDocPath = substr($docDirectory, $extensionDirPosition);
+
+            // Todo: support TYPO3 installations in sub folders
+            // Get Extensions path relative to public path
+            $publicExtPath = substr(Environment::getExtensionsPath(), strlen(Environment::getPublicPath()));
+
+            // Concatenate with extension path
+            $docDirectory = $publicExtPath . DIRECTORY_SEPARATOR . $extDocPath;
+        }
+
+        return $docDirectory;
     }
 
     /**


### PR DESCRIPTION
`$reflectionObject->getFileName()` returns `/var/www/html/packages/project_core/Components/Organisms/Content/TextMedia` when the extension is symlinked by composer from packages to typo3conf/ext.

This is a more dynamic approach to get the relative document directory. But I think it needs more work:
* Currently `substr(Environment::getExtensionsPath(), strlen(Environment::getPublicPath()));` returns "/typo3conf/ext" like it's defined in the class "Environment". If TYPO3 would ever change the extension location we would be save, but for performance we could remove the string handling and just conactenate the strings like: `'/typo3conf/ext/' . $extDocPath`. As done in class "Environment".
* I think if TYPO3 is installed in a subdirectory the image links wouldn't be correct. Actually I don't have this case myself but maybe someone else has.